### PR TITLE
スマートフォンでも見やすくなるように調整

### DIFF
--- a/echo-sd
+++ b/echo-sd
@@ -1081,14 +1081,19 @@ function SD_echo_cgi {
     echo
     echo \
       '<html>' \
-      '<head><title>＞　突然の死　＜ ジェネレーター</title></head>' \
+      '<head>' \
+      '<meta name="viewport" content="width=device-width, initial-scale=1" />' \
+      '<title>＞　突然の死　＜ ジェネレーター</title>' \
       '<style type="text/css"><!--' \
+      'h1 {	word-break: keep-all; }' \
+      'textarea { width: 100%; max-width: 600px; }' \
       '.ul { text-decoration:underline; }' \
       '--></style>' \
-      '<body><h1>＞　突然の死　＜ ジェネレーター</h1>' \
+      '</head>' \
+      '<body><h1>＞　突然の死　＜ <wbr />ジェネレーター</h1>' \
       '<form action="./echo-sd" method="GET">' \
       ;
-    echo -n '<textarea name="scripts" cols="80" rows="4" tabindex="1">'
+    echo -n '<textarea name="scripts" rows="4" tabindex="1">'
     for script in ${scripts[@]+"${scripts[@]}"}; do
       _SD_escape_html "$script"
     done


### PR DESCRIPTION
スマートフォンでも見やすくなるよう、レスポンシブ対応を行いました。
* viewportの追加
* テキストエリアの幅を画面に収まるように調整
* 画面幅により、タイトルを適当なところで改行するように調整

# 改修後のスマートフォン表示
<img width="500" alt="echo-sd" src="https://github.com/user-attachments/assets/ff7e3198-7c05-453a-a861-6d4c89743b60" />
